### PR TITLE
シューズ検索画面のレイアウト修正

### DIFF
--- a/app/assets/stylesheets/shoes.scss
+++ b/app/assets/stylesheets/shoes.scss
@@ -12,21 +12,24 @@
     max-width: 1020px;
     margin-left: auto;
     margin-right: auto;
-    padding: 100px 20px 130px;
+    padding: 60px 20px 60px;
     @include mq(m) {
     width: 750px;
-    padding: 100px 20px 90px;
+    padding: 60px 20px 60px;
   }
   @include mq(s) {
     width: 360px;
-    padding: 100px 20px 90px;
+    padding: 60px 20px 60px;
   }
   }
   &__title {
     text-align: center;
     font-size: 3.2rem;
     font-weight: bold;
-    margin-bottom: 70px;
+    margin-bottom: 60px;
+    @include mq(s) {
+      margin-bottom: 50px;
+    }
   }
   &__explanation{
     font-size: 1.8rem;


### PR DESCRIPTION
シューズの検索画面のレイアウトを修正しました。
ご確認をよろしくお願いします。



↓シューズの検索画面
<img width="528" alt="シューズの検索画面" src="https://user-images.githubusercontent.com/90697671/165082752-b9e44e24-12c5-4bcf-ba0d-f361b95df399.png">
